### PR TITLE
Migrate to Vercel CDN-based static JSON (v2.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+## [2.0.0] - 2026-04-27
+
+### Breaking changes
+
+- 데이터 소스를 Cloud Function (POST) 에서 Vercel CDN (GET) 으로 전환.
+  - 기본 엔드포인트: `https://kdata.vercel.app/api/v1/holidays/{year}.json`
+  - hub 레포: [`kyungseopk1m/kdata`](https://github.com/kyungseopk1m/kdata)
+- 반환 타입을 `Promise<HolidayResponse>` 에서 `Promise<Holiday[]>` 로 단순화. `success` / `message` 래핑 제거 — HTTP status 와 throw 로 성공/실패 판별.
+- 에러는 객체 감싸기 대신 throw.
+  - 4자리 숫자가 아니면 `TypeError`
+  - 2004 미만이거나 `year2 < year` 면 `RangeError`
+  - HTTP 5xx 또는 fetch 실패 시 `Error`
+  - 404 (해당 연도 데이터 미존재) 는 throw 하지 않고 빈 배열 반환
+- `year2` 범위 호출은 서버측 range 응답 대신 연도별 병렬 GET 후 클라이언트에서 머지.
+
+### Added
+
+- `HolidaysOptions { baseUrl?, signal? }` — CDN URL 오버라이드 + AbortSignal 지원.
+- 환경변수 `HOLIDAYS_KR_BASE_URL` — 옵션 미지정 시 기본 baseUrl 대체.
+- `year` / `year2` 가 `string | number` 모두 허용.
+- `Holiday[]` 명시적 export.
+
+### Removed
+
+- Cloud Function 엔드포인트 호출.
+- `X-Holidays-Client` 커스텀 헤더 (CDN GET 으로 불필요).
+- `success` / `message` 응답 필드.
+
+### Migration
+
+```ts
+// Before (v1.x)
+const result = await holidays("2025");
+if (result.success) console.log(result.data);
+
+// After (v2.0.0)
+try {
+  const data = await holidays("2025");
+  console.log(data);
+} catch (e) {
+  // TypeError / RangeError / Error
+}
+```
+
+```ts
+// 자체 미러 / 프록시
+await holidays("2025", undefined, { baseUrl: "https://my-mirror.example.com" });
+
+// 환경변수로도 지정 가능
+// HOLIDAYS_KR_BASE_URL=https://my-mirror.example.com
+await holidays("2025");
+```
+
+```ts
+// AbortSignal
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 5000);
+await holidays("2025", undefined, { signal: controller.signal });
+```
+
+### Notes
+
+- v1.x 사용자 코드는 당분간 동작 (Cloud Function 유지). v2 안정화 이후 별도로 deprecate.
+- 데이터 갱신: GitHub Actions cron 주 1회 → Vercel CDN 재배포.
+
+이전 버전 변경사항은 git log 를 참고.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![npm downloads](https://img.shields.io/npm/dm/@kyungseopk1m/holidays-kr)](https://www.npmjs.com/package/@kyungseopk1m/holidays-kr)
 [![license](https://img.shields.io/npm/l/@kyungseopk1m/holidays-kr)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-supported-blue)](https://www.typescriptlang.org/)
-[![Known Vulnerabilities](https://snyk.io/test/npm/@kyungseopk1m/holidays-kr/badge.svg)](https://snyk.io/test/npm/@kyungseopk1m/holidays-kr)
 [![CodeQL](https://github.com/kyungseopk1m/holidays-kr/actions/workflows/codeql.yml/badge.svg)](https://github.com/kyungseopk1m/holidays-kr/actions/workflows/codeql.yml)
 
 [한국어](#한국어) | [English](#english)
@@ -15,11 +14,11 @@
 
 ### 소개
 
-- 별도의 API 키 없이 단 한 번의 호출로 간편하게 데이터를 가져올 수 있습니다.
-- 모든 데이터는 공공데이터포털을 통해 한국천문연구원의 공식 공휴일 데이터베이스에서 직접 제공됩니다.
-- 2004년 이후의 공휴일 데이터를 제공하며, 매월 3회 정기 업데이트로 최신 정보를 유지합니다.
-- 매년 다음 해의 공휴일 정보를 조회할 수 있지만, 2년 후의 데이터는 포함되지 않습니다.
-- `commonjs`와 `ESM` 모두 지원합니다.
+- 별도의 API 키 없이 단 한 번의 호출로 한국 공휴일 데이터를 가져올 수 있습니다.
+- 모든 데이터는 공공데이터포털을 통해 한국천문연구원의 공식 공휴일 데이터베이스에서 제공됩니다.
+- 2004년 이후의 공휴일 데이터를 제공하며, 정기적으로 갱신됩니다.
+- v2.0.0 부터 **Vercel CDN 기반 정적 JSON** 으로 동작합니다 (이전 Cloud Function 호출 방식 폐기).
+- `commonjs` / `ESM` 모두 지원합니다.
 
 ### 설치
 
@@ -32,42 +31,83 @@ npm i @kyungseopk1m/holidays-kr
 ```typescript
 import { holidays } from "@kyungseopk1m/holidays-kr";
 
-const result = await holidays("2025");
+// 단일 연도
+const data = await holidays("2025");
+console.log(data); // Holiday[] - 2025년 공휴일
 
-console.log(result); // 2025.01 ~ 2025.12 데이터
+// 범위 (연도별 병렬 GET 후 머지)
+const range = await holidays("2024", "2026");
+console.log(range); // 2024 ~ 2026 공휴일
 
-// 또는
-
-const { holidays } = require("@kyungseopk1m/holidays-kr");
-
-const data = await holidays("2010", "2015");
-
-console.log(data); // 2010.01 ~ 2015.12 데이터
+// number 입력도 지원
+const numeric = await holidays(2025);
 ```
 
-### 반환 데이터
-
-| 속성    | 설명                 |
-| ------- | -------------------- |
-| success | API 호출 성공 여부   |
-| message | 응답 메시지          |
-| name    | 공휴일 이름 (한글)   |
-| date    | YYYYMMDD 형식의 날짜 |
-
-<br>
+### 옵션
 
 ```typescript
-interface response {
-  success: boolean;
-  message: string;
-  data: example[];
-}
-
-interface example {
-  date: number;
-  name: string;
+interface HolidaysOptions {
+  baseUrl?: string; // 기본: process.env.HOLIDAYS_KR_BASE_URL ?? "https://kdata.vercel.app"
+  signal?: AbortSignal;
 }
 ```
+
+```typescript
+// 자체 미러 / 프록시 지정
+const data = await holidays("2025", undefined, {
+  baseUrl: "https://my-mirror.example.com",
+});
+
+// AbortSignal 로 취소/타임아웃
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 5000);
+const data2 = await holidays("2025", undefined, { signal: controller.signal });
+
+// 환경변수로 baseUrl 대체
+// HOLIDAYS_KR_BASE_URL=https://my-mirror.example.com
+const data3 = await holidays("2025");
+```
+
+### 반환 / 에러
+
+```typescript
+interface Holiday {
+  date: number; // YYYYMMDD 형식
+  name: string; // 공휴일 이름 (한글)
+}
+
+// 반환: Promise<Holiday[]>
+// - 200: 데이터 배열 반환
+// - 404: 빈 배열 반환 (해당 연도 데이터가 아직 없을 때)
+// - 5xx / network 실패: throw Error
+// - 입력 검증 실패: throw TypeError / RangeError
+```
+
+### 마이그레이션 (v1.x → v2.0.0)
+
+```typescript
+// Before (v1.x)
+const result = await holidays("2025");
+if (result.success) {
+  console.log(result.data);
+}
+
+// After (v2.0.0)
+try {
+  const data = await holidays("2025"); // Holiday[] 직접 반환
+  console.log(data);
+} catch (e) {
+  // TypeError / RangeError / Error
+}
+```
+
+자세한 변경 사항은 [CHANGELOG.md](CHANGELOG.md) 를 참고하세요.
+
+### 데이터 hub
+
+- 데이터 소스 레포: [`kyungseopk1m/kdata`](https://github.com/kyungseopk1m/kdata)
+- 엔드포인트: `https://kdata.vercel.app/api/v1/holidays/{year}.json`
+- 갱신 주기: GitHub Actions cron (주 1회) → Vercel CDN 재배포
 
 ### 라이선스
 
@@ -79,10 +119,10 @@ interface example {
 
 ### Introduction
 
-- No need for a separate API key—just fetch data effortlessly with a single call.
-- All data is sourced directly from the Korea Astronomical Research Institute's official holiday database via the Public Data Portal.
-- Holiday data is available from 2004 onward, with regular updates three times a month to keep it current.
-- You can retrieve holiday information for the upcoming year annually, but data for the year after next is not included.
+- Fetch Korean public holiday data with a single call — no API key required.
+- All data originates from the Korea Astronomical Research Institute via the Public Data Portal.
+- Data is available from 2004 onward and updated regularly.
+- Since v2.0.0, the package reads from **a Vercel-hosted static JSON CDN** (the previous Cloud Function endpoint is retired).
 - Supports both `commonjs` and `ESM`.
 
 ### Install
@@ -96,42 +136,82 @@ npm i @kyungseopk1m/holidays-kr
 ```typescript
 import { holidays } from "@kyungseopk1m/holidays-kr";
 
-const result = await holidays("2025");
+// Single year
+const data = await holidays("2025");
+console.log(data);
 
-console.log(result); // Data from 2025.01 to 2025.12
+// Range (parallel GET per year, then merged)
+const range = await holidays("2024", "2026");
 
-// or
-
-const { holidays } = require("@kyungseopk1m/holidays-kr");
-
-const data = await holidays("2010", "2015");
-
-console.log(data); // Data from 2010.01 to 2015.12
+// Numeric input is also supported
+const numeric = await holidays(2025);
 ```
 
-### Output
-
-| Property | Description               |
-| -------- | ------------------------- |
-| success  | API call success status   |
-| message  | Response message          |
-| name     | Holiday name (in Korean)  |
-| date     | Date in 'YYYYMMDD' format |
-
-<br>
+### Options
 
 ```typescript
-interface response {
-  success: boolean;
-  message: string;
-  data: example[];
-}
-
-interface example {
-  date: number;
-  name: string;
+interface HolidaysOptions {
+  baseUrl?: string; // default: process.env.HOLIDAYS_KR_BASE_URL ?? "https://kdata.vercel.app"
+  signal?: AbortSignal;
 }
 ```
+
+```typescript
+// Custom mirror / proxy
+const data = await holidays("2025", undefined, {
+  baseUrl: "https://my-mirror.example.com",
+});
+
+// AbortSignal for cancellation / timeout
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 5000);
+const data2 = await holidays("2025", undefined, { signal: controller.signal });
+
+// baseUrl override via env var
+// HOLIDAYS_KR_BASE_URL=https://my-mirror.example.com
+const data3 = await holidays("2025");
+```
+
+### Return / Errors
+
+```typescript
+interface Holiday {
+  date: number; // YYYYMMDD
+  name: string; // Holiday name (Korean)
+}
+
+// Return: Promise<Holiday[]>
+// - 200: returns array
+// - 404: returns empty array (data for the requested year is not yet available)
+// - 5xx / network failure: throws Error
+// - validation failure: throws TypeError / RangeError
+```
+
+### Migration (v1.x → v2.0.0)
+
+```typescript
+// Before (v1.x)
+const result = await holidays("2025");
+if (result.success) {
+  console.log(result.data);
+}
+
+// After (v2.0.0)
+try {
+  const data = await holidays("2025"); // returns Holiday[] directly
+  console.log(data);
+} catch (e) {
+  // TypeError / RangeError / Error
+}
+```
+
+See [CHANGELOG.md](CHANGELOG.md) for full release notes.
+
+### Data hub
+
+- Repo: [`kyungseopk1m/kdata`](https://github.com/kyungseopk1m/kdata)
+- Endpoint: `https://kdata.vercel.app/api/v1/holidays/{year}.json`
+- Refresh: GitHub Actions cron (weekly) → Vercel CDN redeploy
 
 ### License
 

--- a/__test__/index.test.ts
+++ b/__test__/index.test.ts
@@ -1,155 +1,232 @@
 import { holidays } from "../src";
 
-describe("holidays", () => {
+const ok = (year: number, data: Array<{ date: number; name: string }>) =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => ({ year, data }),
+  }) as Response;
+
+const notFound = () =>
+  ({
+    ok: false,
+    status: 404,
+    json: async () => ({ error: "Not Found" }),
+  }) as Response;
+
+const serverError = (status = 500) =>
+  ({
+    ok: false,
+    status,
+    json: async () => ({ error: "Server Error" }),
+  }) as Response;
+
+describe("holidays (v2)", () => {
   let fetchSpy: jest.SpyInstance;
+  const originalEnv = process.env.HOLIDAYS_KR_BASE_URL;
 
   beforeEach(() => {
     fetchSpy = jest.spyOn(global, "fetch");
+    delete process.env.HOLIDAYS_KR_BASE_URL;
   });
 
   afterEach(() => {
     fetchSpy.mockRestore();
+    if (originalEnv === undefined) {
+      delete process.env.HOLIDAYS_KR_BASE_URL;
+    } else {
+      process.env.HOLIDAYS_KR_BASE_URL = originalEnv;
+    }
   });
 
-  it("should return an error if the year is not 4 digits or contains non-numeric characters", async () => {
-    const result = await holidays("20a4");
-    expect(result).toEqual({
-      success: false,
-      message: "Please enter the year correctly.",
-      data: [],
+  describe("입력 검증", () => {
+    it("4자리 숫자가 아니면 TypeError", async () => {
+      await expect(holidays("20a4")).rejects.toThrow(TypeError);
+      await expect(holidays("20")).rejects.toThrow(TypeError);
+      await expect(holidays("20250")).rejects.toThrow(TypeError);
+    });
+
+    it("year2가 4자리 숫자가 아니면 TypeError", async () => {
+      await expect(holidays("2024", "20")).rejects.toThrow(TypeError);
+    });
+
+    it("2004 미만이면 RangeError", async () => {
+      await expect(holidays("2003")).rejects.toThrow(RangeError);
+      await expect(holidays(2003)).rejects.toThrow(RangeError);
+    });
+
+    it("year2가 2004 미만이면 RangeError", async () => {
+      await expect(holidays("2010", "2003")).rejects.toThrow(RangeError);
+    });
+
+    it("year2 < year 이면 RangeError", async () => {
+      await expect(holidays("2020", "2010")).rejects.toThrow(RangeError);
+    });
+
+    it('year2 = "" 는 undefined 로 처리 (v1 호환)', async () => {
+      fetchSpy.mockResolvedValueOnce(ok(2024, []));
+      await expect(holidays("2024", "")).resolves.toEqual([]);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("number 타입 year 입력 정상 동작", async () => {
+      fetchSpy.mockResolvedValueOnce(ok(2025, [{ date: 20250101, name: "1월1일" }]));
+      const result = await holidays(2025);
+      expect(result).toEqual([{ date: 20250101, name: "1월1일" }]);
+    });
+
+    it("4자리 미만 number(예: 999) 는 TypeError", async () => {
+      await expect(holidays(999)).rejects.toThrow(TypeError);
     });
   });
 
-  it("should return an error if the year is before 2004", async () => {
-    const result = await holidays("2003");
-    expect(result).toEqual({
-      success: false,
-      message: "Invalid input range. We provide data from 2004 onwards.",
-      data: [],
+  describe("정상 호출", () => {
+    it("단일 연도 GET 요청, 응답 data 반환", async () => {
+      const items = [
+        { date: 20250101, name: "1월1일" },
+        { date: 20250303, name: "삼일절" },
+      ];
+      fetchSpy.mockResolvedValueOnce(ok(2025, items));
+
+      const result = await holidays("2025");
+
+      expect(result).toEqual(items);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchSpy.mock.calls[0];
+      expect(url).toBe("https://kdata.vercel.app/api/v1/holidays/2025.json");
+      expect(init.method).toBe("GET");
+    });
+
+    it("범위 호출 시 연도별 GET 후 데이터를 시간순으로 머지", async () => {
+      fetchSpy
+        .mockResolvedValueOnce(ok(2024, [{ date: 20240101, name: "1월1일" }]))
+        .mockResolvedValueOnce(ok(2025, [{ date: 20250101, name: "1월1일" }]))
+        .mockResolvedValueOnce(ok(2026, [{ date: 20260101, name: "1월1일" }]));
+
+      const result = await holidays("2024", "2026");
+
+      expect(result.map((h) => h.date)).toEqual([20240101, 20250101, 20260101]);
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      const calledUrls = fetchSpy.mock.calls.map((c) => c[0]);
+      expect(calledUrls).toEqual([
+        "https://kdata.vercel.app/api/v1/holidays/2024.json",
+        "https://kdata.vercel.app/api/v1/holidays/2025.json",
+        "https://kdata.vercel.app/api/v1/holidays/2026.json",
+      ]);
+    });
+
+    it("payload.data 가 누락된 응답은 빈 배열로 취급", async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ year: 2025 }),
+      } as Response);
+      const result = await holidays("2025");
+      expect(result).toEqual([]);
     });
   });
 
-  it("should return success and data if the API call is successful", async () => {
-    const mockData = { data: ["holiday1", "holiday2"] };
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => mockData,
-    } as Response);
+  describe("404 처리", () => {
+    it("단일 연도 404 시 빈 배열", async () => {
+      fetchSpy.mockResolvedValueOnce(notFound());
+      const result = await holidays("2099");
+      expect(result).toEqual([]);
+    });
 
-    const result = await holidays("2024");
-    expect(result).toEqual({
-      success: true,
-      message: "Success",
-      data: mockData.data,
+    it("범위 중간 연도 404 는 빈 배열로 머지, 다른 연도 데이터는 유지", async () => {
+      fetchSpy
+        .mockResolvedValueOnce(ok(2025, [{ date: 20250101, name: "1월1일" }]))
+        .mockResolvedValueOnce(notFound())
+        .mockResolvedValueOnce(ok(2027, [{ date: 20270101, name: "1월1일" }]));
+
+      const result = await holidays("2025", "2027");
+      expect(result.map((h) => h.date)).toEqual([20250101, 20270101]);
     });
   });
 
-  it("should return an error if the API call fails", async () => {
-    fetchSpy.mockRejectedValueOnce(new Error("Network Error"));
+  describe("baseUrl 오버라이드", () => {
+    it("options.baseUrl 가 환경변수/기본값보다 우선", async () => {
+      process.env.HOLIDAYS_KR_BASE_URL = "https://env.example.com";
+      fetchSpy.mockResolvedValueOnce(ok(2025, []));
 
-    const result = await holidays("2024");
-    expect(result).toEqual({
-      success: false,
-      message: "Network Error",
-      data: [],
+      await holidays("2025", undefined, {
+        baseUrl: "https://opt.example.com",
+      });
+
+      expect(fetchSpy.mock.calls[0][0]).toBe(
+        "https://opt.example.com/api/v1/holidays/2025.json",
+      );
+    });
+
+    it("HOLIDAYS_KR_BASE_URL 환경변수가 기본값을 대체", async () => {
+      process.env.HOLIDAYS_KR_BASE_URL = "https://env.example.com";
+      fetchSpy.mockResolvedValueOnce(ok(2025, []));
+
+      await holidays("2025");
+
+      expect(fetchSpy.mock.calls[0][0]).toBe(
+        "https://env.example.com/api/v1/holidays/2025.json",
+      );
+    });
+
+    it("baseUrl 끝의 trailing slash 는 정규화", async () => {
+      fetchSpy.mockResolvedValueOnce(ok(2025, []));
+
+      await holidays("2025", undefined, {
+        baseUrl: "https://opt.example.com//",
+      });
+
+      expect(fetchSpy.mock.calls[0][0]).toBe(
+        "https://opt.example.com/api/v1/holidays/2025.json",
+      );
     });
   });
 
-  it("should return an error if year2 is not 4 digits", async () => {
-    const result = await holidays("2024", "20");
-    expect(result).toEqual({
-      success: false,
-      message: "Please enter the year correctly.",
-      data: [],
+  describe("AbortSignal", () => {
+    it("options.signal 이 fetch 에 그대로 전달", async () => {
+      const controller = new AbortController();
+      fetchSpy.mockResolvedValueOnce(ok(2025, []));
+
+      await holidays("2025", undefined, { signal: controller.signal });
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.signal).toBe(controller.signal);
+    });
+
+    it("signal 미지정 시 기본 timeout signal 사용 (AbortSignal 인스턴스)", async () => {
+      fetchSpy.mockResolvedValueOnce(ok(2025, []));
+
+      await holidays("2025");
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it("이미 abort 된 signal 은 fetch 에 그대로 전달되어 reject", async () => {
+      const controller = new AbortController();
+      controller.abort(new Error("aborted by test"));
+      fetchSpy.mockImplementationOnce((_url: string, init: RequestInit) => {
+        if (init.signal?.aborted) {
+          return Promise.reject(init.signal.reason);
+        }
+        return Promise.resolve(ok(2025, []));
+      });
+
+      await expect(
+        holidays("2025", undefined, { signal: controller.signal }),
+      ).rejects.toThrow("aborted by test");
     });
   });
 
-  it("should return an error if year2 is before 2004", async () => {
-    const result = await holidays("2004", "2003");
-    expect(result).toEqual({
-      success: false,
-      message: "Invalid input range. We provide data from 2004 onwards.",
-      data: [],
+  describe("HTTP 에러", () => {
+    it("5xx 응답은 Error throw", async () => {
+      fetchSpy.mockResolvedValueOnce(serverError(500));
+      await expect(holidays("2025")).rejects.toThrow(/HTTP 500/);
     });
-  });
 
-  it("should return an error if year2 is less than year", async () => {
-    const result = await holidays("2020", "2010");
-    expect(result).toEqual({
-      success: false,
-      message: "The end year must be greater than or equal to the start year.",
-      data: [],
-    });
-  });
-
-  it("should return success with year2 parameter", async () => {
-    const mockData = { data: ["holiday1", "holiday2", "holiday3"] };
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => mockData,
-    } as Response);
-
-    const result = await holidays("2020", "2024");
-    expect(result).toEqual({
-      success: true,
-      message: "Success",
-      data: mockData.data,
-    });
-  });
-
-  it("should return an error if a non-Error is thrown", async () => {
-    fetchSpy.mockRejectedValueOnce("string error");
-
-    const result = await holidays("2024");
-    expect(result).toEqual({
-      success: false,
-      message: "Unknown error",
-      data: [],
-    });
-  });
-
-  it("should handle timeout errors", async () => {
-    const abortError = new Error("The operation was aborted due to timeout");
-    abortError.name = "TimeoutError";
-    fetchSpy.mockRejectedValueOnce(abortError);
-
-    const result = await holidays("2024");
-    expect(result).toEqual({
-      success: false,
-      message: "The operation was aborted due to timeout",
-      data: [],
-    });
-  });
-
-  it("should treat empty string year2 as undefined", async () => {
-    const mockData = { data: ["holiday1"] };
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: async () => mockData,
-    } as Response);
-
-    const result = await holidays("2024", "");
-    expect(result).toEqual({
-      success: true,
-      message: "Success",
-      data: mockData.data,
-    });
-  });
-
-  it("should return an error if the API returns a non-200 status", async () => {
-    fetchSpy.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-    } as Response);
-
-    const result = await holidays("2024");
-    expect(result).toEqual({
-      success: false,
-      message: "Failed to fetch holiday data",
-      data: [],
+    it("network 에러는 그대로 propagate", async () => {
+      fetchSpy.mockRejectedValueOnce(new Error("Network Error"));
+      await expect(holidays("2025")).rejects.toThrow("Network Error");
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyungseopk1m/holidays-kr",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "한국천문연구원 기반 대한민국 공휴일 데이터",
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,90 +3,97 @@ export interface Holiday {
   name: string;
 }
 
-export type HolidayResponse =
-  | { success: true; message: string; data: Holiday[] }
-  | { success: false; message: string; data: Holiday[] };
+export interface HolidaysOptions {
+  baseUrl?: string;
+  signal?: AbortSignal;
+}
+
+const DEFAULT_BASE_URL = "https://kdata.vercel.app";
+const DEFAULT_TIMEOUT_MS = 10000;
+const MIN_YEAR = 2004;
+
+const toYearNumber = (input: string | number, label: string): number => {
+  const str = typeof input === "number" ? String(input) : input;
+  if (typeof str !== "string" || !/^\d{4}$/.test(str)) {
+    throw new TypeError(
+      `${label} must be a 4-digit year (string or number). received: ${JSON.stringify(input)}`,
+    );
+  }
+  const num = parseInt(str, 10);
+  if (num < MIN_YEAR) {
+    throw new RangeError(
+      `${label} must be ${MIN_YEAR} or later. received: ${num}`,
+    );
+  }
+  return num;
+};
+
+const resolveBaseUrl = (options?: HolidaysOptions): string => {
+  if (options?.baseUrl) return options.baseUrl.replace(/\/+$/, "");
+  const envUrl =
+    typeof process !== "undefined"
+      ? process.env?.HOLIDAYS_KR_BASE_URL
+      : undefined;
+  return (envUrl && envUrl.length > 0 ? envUrl : DEFAULT_BASE_URL).replace(
+    /\/+$/,
+    "",
+  );
+};
+
+const fetchYear = async (
+  year: number,
+  baseUrl: string,
+  signal: AbortSignal,
+): Promise<Holiday[]> => {
+  const response = await fetch(`${baseUrl}/api/v1/holidays/${year}.json`, {
+    method: "GET",
+    signal,
+  });
+
+  if (response.status === 404) return [];
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch holidays for ${year}: HTTP ${response.status}`,
+    );
+  }
+
+  const payload = (await response.json()) as {
+    year?: number;
+    data?: Holiday[];
+  };
+  return Array.isArray(payload.data) ? payload.data : [];
+};
 
 export const holidays = async (
-  year: string,
-  year2?: string
-): Promise<HolidayResponse> => {
-  if (year2 === "") year2 = undefined;
+  year: string | number,
+  year2?: string | number,
+  options?: HolidaysOptions,
+): Promise<Holiday[]> => {
+  const normalizedYear2 =
+    year2 === "" || year2 === undefined ? undefined : year2;
 
-  if (
-    year.length !== 4 ||
-    (year2 && year2.length !== 4) ||
-    !/^\d+$/.test(year) ||
-    (year2 && !/^\d+$/.test(year2))
-  ) {
-    return {
-      success: false,
-      message: "Please enter the year correctly.",
-      data: [],
-    };
-  }
+  const start = toYearNumber(year, "year");
+  const end =
+    normalizedYear2 !== undefined
+      ? toYearNumber(normalizedYear2, "year2")
+      : start;
 
-  const yearNum = parseInt(year, 10);
-  const year2Num = year2 ? parseInt(year2, 10) : undefined;
-
-  if (yearNum < 2004 || (year2Num !== undefined && year2Num < 2004)) {
-    return {
-      success: false,
-      message: "Invalid input range. We provide data from 2004 onwards.",
-      data: [],
-    };
-  }
-
-  if (year2Num !== undefined && year2Num < yearNum) {
-    return {
-      success: false,
-      message: "The end year must be greater than or equal to the start year.",
-      data: [],
-    };
-  }
-
-  try {
-    const response = await fetch(
-      "https://scheduler-getholidaydate-lkny2xhv4a-du.a.run.app",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          year,
-          year2,
-        }),
-        signal: AbortSignal.timeout(10000),
-      }
+  if (end < start) {
+    throw new RangeError(
+      `year2 must be greater than or equal to year. received: year=${start}, year2=${end}`,
     );
-
-    if (!response.ok) {
-      return {
-        success: false,
-        message: "Failed to fetch holiday data",
-        data: [],
-      };
-    }
-
-    const result: { data?: Holiday[] } = await response.json();
-
-    return {
-      success: true,
-      message: "Success",
-      data: result?.data ?? [],
-    };
-  } catch (error) {
-    return error instanceof Error
-      ? {
-          success: false,
-          message: error.message,
-          data: [],
-        }
-      : {
-          success: false,
-          message: "Unknown error",
-          data: [],
-        };
   }
+
+  const baseUrl = resolveBaseUrl(options);
+  const signal = options?.signal ?? AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+
+  const years: number[] = [];
+  for (let y = start; y <= end; y++) years.push(y);
+
+  const buckets = await Promise.all(
+    years.map((y) => fetchYear(y, baseUrl, signal)),
+  );
+
+  return buckets.flat();
 };


### PR DESCRIPTION
## 요약

데이터 소스를 Cloud Function POST 호출에서 Vercel CDN 정적 JSON GET 으로 전환한다.
GHA cron 이 [kdata](https://github.com/kyungseopk1m/kdata) 레포에 한국천문연구원 데이터를 갱신하면 Vercel 이 자동 재배포하는 hub 구조로 운영을 분리.

## Breaking changes

- 반환 타입: `Promise<HolidayResponse>` → `Promise<Holiday[]>` (success/message 제거)
- 검증/HTTP 실패는 throw, 404 는 빈 배열
- year2 범위는 연도별 병렬 GET 후 클라이언트에서 머지 (서버측 range 응답 폐기)
- `HolidaysOptions { baseUrl, signal }` 옵션 + `HOLIDAYS_KR_BASE_URL` env 추가
- year / year2 모두 `string | number` 허용

자세한 마이그레이션 가이드는 [CHANGELOG.md](https://github.com/kyungseopk1m/holidays-kr/blob/feat/v2-cdn-migration/CHANGELOG.md) 참고.

## 검증

- `npm test` 21건 통과 (입력 검증 / 정상 호출 / 404 / baseUrl override / AbortSignal / HTTP 에러)
- `npm run build` 성공 — dual CJS/ESM + d.ts 정상 emit
- 라이브 CDN 통합 테스트 (CJS + ESM): 단일/범위 호출, 404, env override, trailing slash 정규화, pre-aborted signal 모두 정상

## 후속

- merge 후 `npm publish --access=public --provenance`
- v1.x README deprecation 배너 + `npm deprecate` 는 별도 PR